### PR TITLE
Rename app to "WebPushTest" and other fixes

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Push Test",
-  "short_name": "PushTest",
+  "name": "Web Push Test",
+  "short_name": "WebPushTest",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#90cdf4",

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -22,23 +22,26 @@ export default function Footer(props: {
             className="bg-section h-10 flex justify-center px-2 cursor-pointer icon-hoverable"
             title="Toggle device details"
           >
-            {props.open ? (
-              <Image
-                src="/arrow-down.svg"
-                width={20}
-                height={20}
-                alt="arrow-down"
-                className="icon-hover-down"
-              />
-            ) : (
-              <Image
-                src="/arrow-up.svg"
-                width={20}
-                height={20}
-                alt="arrow-up"
-                className="icon-hover-up"
-              />
-            )}
+            <div className="flex items-center justify-center gap-x-4 text-text font-light text-xs">
+              <span>Toggle device information</span>
+              {props.open ? (
+                <Image
+                  src="/arrow-down.svg"
+                  width={20}
+                  height={20}
+                  alt="arrow-down"
+                  className="icon-hover-down"
+                />
+              ) : (
+                <Image
+                  src="/arrow-up.svg"
+                  width={20}
+                  height={20}
+                  alt="arrow-up"
+                  className="icon-hover-up"
+                />
+              )}
+            </div>
           </div>
         </Collapsible.Trigger>
         <Collapsible.Content>

--- a/src/components/info.tsx
+++ b/src/components/info.tsx
@@ -28,7 +28,7 @@ export default function Info({ info }: { info: DeviceInfo }) {
         }}
       >
         <ul
-          className="grid grid-cols-2 gap-x-8 gap-y-2 bg-section text-gray-100 p-4 rounded-lg text-xs md:text-lg relative"
+          className="grid grid-cols-2 gap-x-8 gap-y-2 bg-section text-gray-100 p-4 rounded-lg text-xs md:text-lg relative pb-10"
           ref={infoRef}
         >
           {info &&
@@ -53,6 +53,23 @@ export default function Info({ info }: { info: DeviceInfo }) {
         <Toast.Description asChild></Toast.Description>
       </Toast.Root>
       <Toast.Viewport className="ToastViewport" />
+      <p className="w-full flex justify-center items-center gap-x-2 absolute bottom-0 left-0 text-muted text-xs p-2 pointer-events-none text-center">
+        <svg
+          width="15"
+          height="15"
+          viewBox="0 0 15 15"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.49991 0.876892C3.84222 0.876892 0.877075 3.84204 0.877075 7.49972C0.877075 11.1574 3.84222 14.1226 7.49991 14.1226C11.1576 14.1226 14.1227 11.1574 14.1227 7.49972C14.1227 3.84204 11.1576 0.876892 7.49991 0.876892ZM1.82707 7.49972C1.82707 4.36671 4.36689 1.82689 7.49991 1.82689C10.6329 1.82689 13.1727 4.36671 13.1727 7.49972C13.1727 10.6327 10.6329 13.1726 7.49991 13.1726C4.36689 13.1726 1.82707 10.6327 1.82707 7.49972ZM8.24992 4.49999C8.24992 4.9142 7.91413 5.24999 7.49992 5.24999C7.08571 5.24999 6.74992 4.9142 6.74992 4.49999C6.74992 4.08577 7.08571 3.74999 7.49992 3.74999C7.91413 3.74999 8.24992 4.08577 8.24992 4.49999ZM6.00003 5.99999H6.50003H7.50003C7.77618 5.99999 8.00003 6.22384 8.00003 6.49999V9.99999H8.50003H9.00003V11H8.50003H7.50003H6.50003H6.00003V9.99999H6.50003H7.00003V6.99999H6.50003H6.00003V5.99999Z"
+            fill="currentColor"
+            fillRule="evenodd"
+            clipRule="evenodd"
+          ></path>
+        </svg>
+        Click anywhere in panel to copy details to clipboard
+      </p>
     </Toast.Provider>
   )
 }

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export default function Links() {
   return (
     <section
-      className="text-center my-8 grid items-center justify-center gap-x-4 gap-y-8 bg-section p-4 rounded-lg border-primary border-opacity-50 border-2"
+      className="text-center my-8 grid items-center justify-center gap-x-4 gap-y-8 bg-section p-4 rounded-lg border-primary border-opacity-50 border-2 max-w-sm mx-auto"
       style={{
         gridTemplateColumns: "fit-content(100px) fit-content(500px)",
       }}
@@ -47,7 +47,7 @@ export default function Links() {
             fill="currentColor"
           />
         </svg>
-        <span className="text-sm">Go to Twitter accouncement</span>
+        <span className="text-sm">A thread about web-push on iOS 16.5</span>
       </a>
     </section>
   )

--- a/src/components/subscriber.tsx
+++ b/src/components/subscriber.tsx
@@ -163,7 +163,7 @@ export default function Subscriber({
         classname="bg-primary"
         disabled={false}
       />
-      <p className="text-xs my-6">
+      <p className="text-xs mt-6 mb-16">
         * Once you subscribe we will send you one automatic test-notification.
         You can unsubscribe at any time.
       </p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -52,18 +52,20 @@ body,
     }
     .icon-hoverable:hover {
     }
-    .icon-hoverable .icon-hover-down,
-    .icon-hoverable .icon-hover-up {
+    .icon-hoverable *{
         opacity: 0.7;
         transition: all 0.2s ease-in-out;
     }
-    .icon-hoverable:hover .icon-hover-down {
+
+    .icon-hoverable:hover * {
         opacity: 1;
+    }
+
+    .icon-hoverable:hover .icon-hover-down {
         transform: translateY(2px);
     }
 
     .icon-hoverable:hover .icon-hover-up {
-        opacity: 1;
         transform: translateY(-2px);
     }
 


### PR DESCRIPTION
- narrow the links section to phone width
- change twitter text to “A thread on web-push on iOS16.5”
- add more space after the “once you subscribe” text
- add label to toggle device info panel
- add label to “click to copy to clipboard”
- changes name in manifest.json to WebPushTest