### PR TITLE
Fix typo in readme, add more links to important source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It will hopefully also be useful for developers, who can use it as a basis for p
 
 Relevant links:
 
-- [Magic bell now supports push notifications (and why you should care)](https://www.magicbell.com/blog/ios-now-supports-web-push-notifications-and-why-you-should-care)
+- [iOS now supports push notifications (and why you should care)](https://www.magicbell.com/blog/ios-now-supports-web-push-notifications-and-why-you-should-care)
 - [Twitter thread](https://twitter.com/Matt0xley/status/1668912123702030336)
 - Link to our [Slack power-users group](https://magicbell.to/slack)
 
@@ -52,3 +52,4 @@ These will be the most relevant files to look at if you want to understand how t
 - https://github.com/magicbell-io/webpush-test/blob/main/src/components/subscriber.tsx
 - https://github.com/magicbell-io/webpush-test/blob/main/src/services/subscriptionManager.ts
 - https://github.com/magicbell-io/webpush-test/blob/main/public/manifest.json
+- https://github.com/magicbell-io/webpush-test/blob/main/public/sw.js


### PR DESCRIPTION
- fixes a typo
- adds a link to the service worker registration file, highlighting it as important